### PR TITLE
Fix typo and improve HostedExcelAddIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ public class QuickStartFunctions
     [ExcelFunction(Description = "Say hello to somebody")]
     public string SayHello(string name)
     {
-        _quickStartService.SayHello(name);
+        return _quickStartService.SayHello(name);
     }
 }
 ```
@@ -116,7 +116,7 @@ public class QuickStartRibbon : HostedExcelRibbon
 
 Derive a class from `HostedExcelAddIn` and implement `CreateHostBuilder` abstract method.
 Register your services, `ExcelFunction`s container classes, and `ExcelRibbon`s using `ConfigureServices` method.
-Here we use `Host.CreateDefaultBuilder()` from `Microsfot.Extensions.Hosting` (must be installed separately).
+Here we use `Host.CreateDefaultBuilder()` from `Microsoft.Extensions.Hosting` (must be installed separately).
 
 ```cs
 public class QuickStartAddIn : HostedExcelAddIn

--- a/Source/ExcelRna.Extensions.Hosting.Tests/HostedExcelAddInTests.cs
+++ b/Source/ExcelRna.Extensions.Hosting.Tests/HostedExcelAddInTests.cs
@@ -39,6 +39,39 @@ public class HostedExcelAddInTests
         Assert.Equal(2, invalidExcelAddIn.Exceptions.Count);
     }
 
+    [Fact]
+    public void HostedExcelAddIn_AutoClose_without_AutoOpen_should_not_throw()
+    {
+        // ARRANGE
+        var testExcelAddIn = new TestExcelAddIn();
+        IExcelAddIn addIn = testExcelAddIn;
+
+        // ACT
+        Exception? exception = Record.Exception(addIn.AutoClose);
+
+        // ASSERT
+        Assert.Null(exception);
+        Assert.False(testExcelAddIn.IsRunning);
+    }
+
+    [Fact]
+    public void HostedExcelAddIn_AutoClose_can_be_called_multiple_times()
+    {
+        // ARRANGE
+        var testExcelAddIn = new TestExcelAddIn();
+        IExcelAddIn addIn = testExcelAddIn;
+
+        addIn.AutoOpen();
+        addIn.AutoClose();
+
+        // ACT
+        Exception? exception = Record.Exception(addIn.AutoClose);
+
+        // ASSERT
+        Assert.Null(exception);
+        Assert.False(testExcelAddIn.IsRunning);
+    }
+
     private class TestExcelAddIn : HostedExcelAddIn, IHostedService
     {
         public bool IsRunning { get; private set; }

--- a/Source/ExcelRna.Extensions.Hosting/HostedExcelAddIn.cs
+++ b/Source/ExcelRna.Extensions.Hosting/HostedExcelAddIn.cs
@@ -43,9 +43,15 @@ public abstract class HostedExcelAddIn : IExcelAddIn
     {
         try
         {
+            if (_host == null)
+            {
+                return;
+            }
+
             AutoClose(_host);
             _host.StopAsync().GetAwaiter().GetResult();
             _host.Dispose();
+            _host = null;
         }
         catch (Exception e)
         {

--- a/Source/ExcelRna.Extensions.Logging.Tests/LogDisplayLoggerProviderTests.cs
+++ b/Source/ExcelRna.Extensions.Logging.Tests/LogDisplayLoggerProviderTests.cs
@@ -55,6 +55,21 @@ public class LogDisplayLoggerProviderTests
         Assert.Equal(LogLevel.Trace, logger.Options.AutoShowLogDisplayThreshold);
     }
 
+    [Fact]
+    public void CreateLogger_returns_same_logger_for_same_name()
+    {
+        // ARRANGE
+        var optionsMonitor = Mock.Of<IOptionsMonitor<LogDisplayLoggerOptions>>(m => m.CurrentValue == new LogDisplayLoggerOptions());
+        var provider = new LogDisplayLoggerProvider(optionsMonitor);
+
+        // ACT
+        ILogger logger1 = provider.CreateLogger("Test");
+        ILogger logger2 = provider.CreateLogger("Test");
+
+        // ASSERT
+        Assert.Same(logger1, logger2);
+    }
+
     private class TestOptionsMonitor<TOptions> : IOptionsMonitor<TOptions>
         where TOptions : class, new()
     {


### PR DESCRIPTION
## Summary
- fix README typo and update sample snippet
- safeguard `HostedExcelAddIn.AutoClose` against null host
- add caching test for `LogDisplayLoggerProvider`

## Testing
- `dotnet test --no-build -p:CollectCoverage=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b66a44ac8330bbca0f25bbd506cc